### PR TITLE
Issue #12: Not all blocks are custom blocks.

### DIFF
--- a/quicktabs.admin.inc
+++ b/quicktabs.admin.inc
@@ -311,6 +311,9 @@ function _quicktabs_form(array $tab, $qt) {
       }
     }
     $tabtypes[$name] = $name;
+    if ($tabtypes[$name] == 'block') {
+      $tabtypes[$name] = 'custom block';
+    }
     $content_provider = quick_content_factory($name, $tab);
     if (is_object($content_provider)) {
       $form = array_merge_recursive($form, $content_provider->optionsForm($delta, $qt));


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/quicktabs/issues/12